### PR TITLE
Add first working 'vagrant-cloud-standalone' implementation

### DIFF
--- a/artifact.go
+++ b/artifact.go
@@ -1,10 +1,10 @@
-package vagrantcloud
+package main
 
 import (
 	"fmt"
 )
 
-const BuilderId = "pearkes.post-processor.vagrant-cloud"
+const BuilderId = "pearkes.post-processor.vagrant-cloud-standalone"
 
 type Artifact struct {
 	Tag      string

--- a/artifact_test.go
+++ b/artifact_test.go
@@ -1,4 +1,4 @@
-package vagrantcloud
+package main
 
 import (
 	"testing"

--- a/client.go
+++ b/client.go
@@ -1,4 +1,4 @@
-package vagrantcloud
+package main
 
 import (
 	"bytes"

--- a/main.go
+++ b/main.go
@@ -1,0 +1,13 @@
+package main
+
+import "github.com/hashicorp/packer/packer/plugin"
+
+func main() {
+	server, err := plugin.Server()
+	if err != nil {
+		panic(err)
+	}
+
+	server.RegisterPostProcessor(new(PostProcessor))
+	server.Serve()
+}

--- a/post-processor_test.go
+++ b/post-processor_test.go
@@ -1,4 +1,4 @@
-package vagrantcloud
+package main
 
 import (
 	"bytes"

--- a/step_create_provider.go
+++ b/step_create_provider.go
@@ -1,4 +1,4 @@
-package vagrantcloud
+package main
 
 import (
 	"context"

--- a/step_create_version.go
+++ b/step_create_version.go
@@ -1,4 +1,4 @@
-package vagrantcloud
+package main
 
 import (
 	"context"

--- a/step_prepare_upload.go
+++ b/step_prepare_upload.go
@@ -1,4 +1,4 @@
-package vagrantcloud
+package main
 
 import (
 	"context"

--- a/step_release_version.go
+++ b/step_release_version.go
@@ -1,4 +1,4 @@
-package vagrantcloud
+package main
 
 import (
 	"context"

--- a/step_upload.go
+++ b/step_upload.go
@@ -1,4 +1,4 @@
-package vagrantcloud
+package main
 
 import (
 	"context"

--- a/step_verify_box.go
+++ b/step_verify_box.go
@@ -1,4 +1,4 @@
-package vagrantcloud
+package main
 
 import (
 	"context"


### PR DESCRIPTION
Default Packer `vagrant-cloud` relies on state of `vagrant` post-processor which must be ran before.
It's not possible to run `vagrant-cloud` in a standalone mode, just having `.box` artifact to upload.


This PR unties `vagrant-cloud` from `vagrant` post processor, allowing to deploy `artifact` from file path.

Example post-processor:
```json
  "post-processors": [
    {
      "type": "vagrant-cloud-standalone",
      "access_token": "{{user `cloud_token`}}",
      "box_tag": "stackstorm/st2",
      "provider": "virtualbox",
      "version": "{{user `st2_version`}}-{{user `box_version`}}",
      "artifact": "builds/{{user `vm_name`}}_v{{user `st2_version`}}-{{user `box_version`}}.box"
    }
  ]
```

Here, 2 new params `provider` and `artifact` which takes file path to the box file and.
Previously, they were takes from the previous post-processor step.